### PR TITLE
nixos/parity: add NixOS tests for parity service

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3903,6 +3903,11 @@
     github = "stites";
     name = "Sam Stites";
   };
+  strdn = {
+    email = "ilichev.evgenii@gmail.com";
+    github = "strdn";
+    name = "Evgeny Ilyichev";
+  };
   stumoss = {
     email = "samoss@gmail.com";
     github = "stumoss";

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -407,6 +407,7 @@ in rec {
   tests.opensmtpd = callTest tests/opensmtpd.nix {};
   tests.owncloud = callTest tests/owncloud.nix {};
   tests.pam-oath-login = callTest tests/pam-oath-login.nix {};
+  tests.parity = callTest tests/parity.nix {};
   tests.peerflix = callTest tests/peerflix.nix {};
   tests.php-pcre = callTest tests/php-pcre.nix {};
   tests.postgresql = callSubTests tests/postgresql.nix {};

--- a/nixos/tests/parity.nix
+++ b/nixos/tests/parity.nix
@@ -1,5 +1,4 @@
-
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix ({ pkgs, ... } : {
   name = "parity";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ strdn akru ];


### PR DESCRIPTION
###### Motivation for this change
add parity service to NixOS upstream

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

