### PR TITLE
add multihash python module

### DIFF
--- a/pkgs/applications/science/robotics/aira/robonomics_dev/default.nix
+++ b/pkgs/applications/science/robotics/aira/robonomics_dev/default.nix
@@ -26,7 +26,7 @@ in mkRosPackage {
   propagatedBuildInputs = with python3Packages;
   [ catkin ros_comm actionlib ros_opcua_communication
     base58 pexpect ipfsapi numpy web3 google_api_python_client
-    robonomics_comm_ethereum_common voluptuous
+    robonomics_comm_ethereum_common voluptuous multihash
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/multihash/default.nix
+++ b/pkgs/development/python-modules/multihash/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub }:
+
+buildPythonPackage rec {
+  pname = "multihash";
+  version = "0.8.2";
+
+  src = fetchFromGitHub {
+    owner = "ivilata";
+    repo = "pymultihash";
+    rev = "3b4ea39e132b5f713cdd745fc6ff117f65116c40";
+    sha256 = "0wdxrxss1rv7rrydnwnb2wbfv5nazlm6n6mv7hx61hpblwhyfq9y";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Implementation of the multihash specification in Python";
+    homepage = https://github.com/multiformats/multihash;
+    license = licenses.mit;
+    maintainers = [ maintainers.strdn ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16720,6 +16720,8 @@ EOF
 
   simpy = callPackage ../development/python-modules/simpy { };
 
+  multihash = callPackage ../development/python-modules/multihash { };
+
   z3 = (toPythonModule (pkgs.z3.override {
     inherit python;
   })).python;


### PR DESCRIPTION
airalab/aira#66

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

