### PR TITLE
ros-modules: update to melodic

### DIFF
--- a/pkgs/development/ros-modules/catkin/default.nix
+++ b/pkgs/development/ros-modules/catkin/default.nix
@@ -7,7 +7,8 @@
 
 let
   pname = "catkin";
-  version = "0.7.11";
+  version = "0.7.14";
+  rosdistro = "melodic";
 
 in stdenv.mkDerivation {
   name = "${pname}-${version}";
@@ -15,8 +16,8 @@ in stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "ros-gbp";
     repo = "${pname}-release";
-    rev = "release/lunar/${pname}/${version}-0";
-    sha256 = "04abn7a1vaxb9ri2qk3rb3g63l3xmg3fp8c10f4y639m1mpixj5n";
+    rev = "release/${rosdistro}/${pname}/${version}-0";
+    sha256 = "0dhfm1mya467dv6qc6j86f0yxbwqgvf2319p2r6bpvngjby51d86";
   };
   
   propagatedBuildInputs = with python3Packages; [ catkin_pkg rospkg empy cmake ];

--- a/pkgs/development/ros-modules/ros/default.nix
+++ b/pkgs/development/ros-modules/ros/default.nix
@@ -15,7 +15,8 @@
 
 let
   pname = "ros";
-  version = "1.14.1";
+  version = "1.14.4";
+  rosdistro = "melodic";
 
 in mkRosPackage {
   name = "${pname}-${version}";
@@ -23,8 +24,8 @@ in mkRosPackage {
   src = fetchFromGitHub {
     owner = "ros-gbp";
     repo = "${pname}-release";
-    rev = "release/lunar/${pname}/${version}-0";
-    sha256 = "0rjpfmdcqnpxy0w2iyacn547ix7h4fh4h8jcvxm0hx58zfvfpzqk";
+    rev = "release/${rosdistro}/${pname}/${version}-0";
+    sha256 = "1zvm652m90fq2wzpl1s6ay45z6sbv2pgbx6wfz47kshvvs4yd2w3";
   };
 
   propagatedBuildInputs = [ catkin rosbash rosboost_cfg rosbuild rosclean

--- a/pkgs/development/ros-modules/ros_comm/default.nix
+++ b/pkgs/development/ros-modules/ros_comm/default.nix
@@ -27,7 +27,8 @@
 
 let
   pname = "ros_comm";
-  version = "1.13.6";
+  version = "1.14.4";
+  rosdistro = "melodic";
 
 in mkRosPackage {
   name = "${pname}-${version}";
@@ -35,8 +36,8 @@ in mkRosPackage {
   src = fetchFromGitHub {
     owner = "ros-gbp";
     repo = "ros_comm-release";
-    rev = "release/lunar/${pname}/${version}-0";
-    sha256 = "1scbxsilx3xrv5lk57nk2crw8cchh0yp1216bmphyqjfp9vi987r";
+    rev = "release/${rosdistro}/${pname}/${version}-0";
+    sha256 = "0csdbk0hksvl08831brvnk7yg8p5gyxb4va822zyh31k17axnks2";
   };
 
   propagatedBuildInputs =

--- a/pkgs/development/ros-modules/rosbag/default.nix
+++ b/pkgs/development/ros-modules/rosbag/default.nix
@@ -14,11 +14,15 @@
 , rospy
 , topic_tools
 , xmlrpcpp
+, pluginlib
+, gpgme
+, openssl
 }:
 
 let
   pname = "rosbag";
-  version = "1.13.6";
+  version = "1.14.4";
+  rosdistro = "melodic";
 
 in mkRosPackage {
   name = "${pname}-${version}";
@@ -26,13 +30,14 @@ in mkRosPackage {
   src = fetchFromGitHub {
     owner = "ros-gbp";
     repo = "ros_comm-release";
-    rev = "release/lunar/${pname}/${version}-0";
-    sha256 = "1v9r4fybd594ks2gj7k2yxyyx0c5h177y69i29p6zf2vbvsa0jrh";
+    rev = "release/${rosdistro}/${pname}/${version}-0";
+    sha256 = "1fl50gmnd6p5wlyjfvhh547bmffy9f9kkrfvrsb4g6mcpr2k6hn9";
   };
 
   propagatedBuildInputs =
   [ catkin cpp_common genmsg genpy rosbag_storage rosconsole std_srvs
-    roscpp roscpp_serialization roslib rospy topic_tools xmlrpcpp ];
+    roscpp roscpp_serialization roslib rospy topic_tools xmlrpcpp
+    pluginlib gpgme openssl ];
 
   meta = with stdenv.lib; {
     description = "Set of tools for recording from and playing back to ROS topics";

--- a/pkgs/development/ros-modules/rosbag/storage.nix
+++ b/pkgs/development/ros-modules/rosbag/storage.nix
@@ -9,11 +9,15 @@
 , roslz4
 , bzip2
 , rostime
+, pluginlib
+, gpgme
+, openssl
 }:
 
 let
   pname = "rosbag_storage";
-  version = "1.13.6";
+  version = "1.14.4";
+  rosdistro = "melodic";
 
 in mkRosPackage {
   name = "${pname}-${version}";
@@ -21,12 +25,13 @@ in mkRosPackage {
   src = fetchFromGitHub {
     owner = "ros-gbp";
     repo = "ros_comm-release";
-    rev = "release/lunar/${pname}/${version}-0";
-    sha256 = "0vlv9xzm9v5gy7lzmpd7fs74vp26jbciapdlwna91l0x0jxaivii";
+    rev = "release/${rosdistro}/${pname}/${version}-0";
+    sha256 = "0wx70hmm75ahgy0m6xq8qawf9lq7g7dnhkwapmnm8craml720lnl";
   };
 
   propagatedBuildInputs = [ catkin cpp_common console_bridge roscpp_serialization
-                            roscpp_traits roslz4 bzip2 rostime];
+                            roscpp_traits roslz4 bzip2 rostime
+                            pluginlib gpgme openssl ];
 
   meta = with stdenv.lib; {
     description = "This is a set of tools for recording from and playing back ROS message without relying on the ROS client library";

--- a/pkgs/development/ros-modules/rosbash/default.nix
+++ b/pkgs/development/ros-modules/rosbash/default.nix
@@ -6,7 +6,8 @@
 
 let
   pname = "rosbash";
-  version = "1.14.1";
+  version = "1.14.4";
+  rosdistro = "melodic";
 
 in mkRosPackage {
   name = "${pname}-${version}";
@@ -14,8 +15,8 @@ in mkRosPackage {
   src = fetchFromGitHub {
     owner = "ros-gbp";
     repo = "ros-release";
-    rev = "release/lunar/${pname}/${version}-0";
-    sha256 = "16rpma98ggck93cx73w6kgchd5zq59dgy81601f5dznf77ksipx4";
+    rev = "release/${rosdistro}/${pname}/${version}-0";
+    sha256 = "0y7zkrfya3i1vzqsfmpgwjhiglavkm5sk70lk7gpng19g9f8psp8";
   };
 
   propagatedBuildInputs = [ catkin ];

--- a/pkgs/development/ros-modules/rosboost_cfg/default.nix
+++ b/pkgs/development/ros-modules/rosboost_cfg/default.nix
@@ -6,7 +6,8 @@
 
 let
   pname = "rosboost_cfg";
-  version = "1.14.1";
+  version = "1.14.4";
+  rosdistro = "melodic";
 
 in mkRosPackage {
   name = "${pname}-${version}";
@@ -14,8 +15,8 @@ in mkRosPackage {
   src = fetchFromGitHub {
     owner = "ros-gbp";
     repo = "ros-release";
-    rev = "release/lunar/${pname}/${version}-0";
-    sha256 = "051psvfx6qw9swia21azk45cwzm9wvpnfjyfh3sy7b6ri0h8zyhj";
+    rev = "release/${rosdistro}/${pname}/${version}-0";
+    sha256 = "0ymdfrdhr0kkk4cxbrqs13jk5cjx4dc2w0s7ac78bv1sa91dhlgn";
   };
 
   propagatedBuildInputs = [ catkin ];

--- a/pkgs/development/ros-modules/rosbuild/default.nix
+++ b/pkgs/development/ros-modules/rosbuild/default.nix
@@ -8,7 +8,8 @@
 
 let
   pname = "rosbuild";
-  version = "1.14.1";
+  version = "1.14.4";
+  rosdistro = "melodic";
 
 in mkRosPackage {
   name = "${pname}-${version}";
@@ -16,8 +17,8 @@ in mkRosPackage {
   src = fetchFromGitHub {
     owner = "ros-gbp";
     repo = "ros-release";
-    rev = "release/lunar/${pname}/${version}-0";
-    sha256 = "0npnkkfyr5nrxr1g9kak1i2cjc6vmz87v1p89901yawcl1g8hkix";
+    rev = "release/${rosdistro}/${pname}/${version}-0";
+    sha256 = "0xarzviz72yihmngy0wjz1lkra4xgx5zr11ddqw2xvsca8xsa4kw";
   };
 
   propagatedBuildInputs = [ catkin message_generation message_runtime ];

--- a/pkgs/development/ros-modules/rosclean/default.nix
+++ b/pkgs/development/ros-modules/rosclean/default.nix
@@ -6,7 +6,8 @@
 
 let
   pname = "rosclean";
-  version = "1.14.1";
+  version = "1.14.4";
+  rosdistro = "melodic";
   
 in mkRosPackage {
   name = "${pname}-${version}";
@@ -14,8 +15,8 @@ in mkRosPackage {
   src = fetchFromGitHub {
     owner = "ros-gbp";
     repo = "ros-release";
-    rev = "release/lunar/${pname}/${version}-0";
-    sha256 = "1pv3wfdmjbyrchyznnh1qxhybm9l14hwacqzz8gigc584wa76ivz";
+    rev = "release/${rosdistro}/${pname}/${version}-0";
+    sha256 = "10k6ld40nh3f09nqy54qdayxf915x3vyf9la8ky3jk7f2i8qzm1c";
   };
 
   propagatedBuildInputs = [ catkin ];

--- a/pkgs/development/ros-modules/rosconsole/default.nix
+++ b/pkgs/development/ros-modules/rosconsole/default.nix
@@ -12,7 +12,7 @@
 
 let
   pname = "rosconsole";
-  version = "1.13.7";
+  version = "1.14.4";
   rosdistro = "melodic";
 
 in mkRosPackage {
@@ -22,7 +22,7 @@ in mkRosPackage {
     owner = "ros-gbp";
     repo = "${pname}-release";
     rev = "release/${rosdistro}/${pname}/${version}-0";
-    sha256 = "0y8avp88hq0h1qi83j9c4jhp92ir8awx82mkgh29r1cp0cyj4nfi";
+    sha256 = "06sjhlx8cs4xmcxgwnw7jxs5xgzpjs31n6fsjbrxz659dw234al3";
   };
 
   propagatedBuildInputs = [ catkin boost cpp_common log4cxx rosbuild rostime rosunit ];

--- a/pkgs/development/ros-modules/rosconsole_bridge/default.nix
+++ b/pkgs/development/ros-modules/rosconsole_bridge/default.nix
@@ -8,7 +8,7 @@
 
 let
   pname = "rosconsole_bridge";
-  version = "0.5.1";
+  version = "0.5.2";
   rosdistro = "melodic";
 
 in mkRosPackage {
@@ -18,7 +18,7 @@ in mkRosPackage {
     owner = "ros-gbp";
     repo = "${pname}-release";
     rev = "release/${rosdistro}/${pname}/${version}-0";
-    sha256 = "1l733r4zd6417k5alk921hbrz6xnk98rvfdvm9llpd4dihf01hj8";
+    sha256 = "0y6j9w8p3gifq6jv5931d15gv3c12yfsaikncfrf628abp037sj8";
   };
 
   propagatedBuildInputs = [ catkin console_bridge rosconsole ];

--- a/pkgs/development/ros-modules/roscpp/default.nix
+++ b/pkgs/development/ros-modules/roscpp/default.nix
@@ -17,7 +17,8 @@
 
 let
   pname = "roscpp";
-  version = "1.13.6";
+  version = "1.14.4";
+  rosdistro = "melodic";
 
 in mkRosPackage {
   name = "${pname}-${version}";
@@ -25,8 +26,8 @@ in mkRosPackage {
   src = fetchFromGitHub {
     owner = "ros-gbp";
     repo = "ros_comm-release";
-    rev = "release/lunar/${pname}/${version}-0";
-    sha256 = "12rkyhk92xh2pgq27mpsvmwn3zsns31scfvnmzdflh8mgrwygrrs";
+    rev = "release/${rosdistro}/${pname}/${version}-0";
+    sha256 = "14ijc55ikh9sdkf6s8zv78lcns1lwb6gadg9vk3m516kl7m2847v";
   };
 
   propagatedBuildInputs =

--- a/pkgs/development/ros-modules/roscreate/default.nix
+++ b/pkgs/development/ros-modules/roscreate/default.nix
@@ -6,7 +6,8 @@
 
 let
   pname = "roscreate";
-  version = "1.14.1";
+  version = "1.14.4";
+  rosdistro = "melodic";
 
 in mkRosPackage {
   name = "${pname}-${version}";
@@ -14,8 +15,8 @@ in mkRosPackage {
   src = fetchFromGitHub {
     owner = "ros-gbp";
     repo = "ros-release";
-    rev = "release/lunar/${pname}/${version}-0";
-    sha256 = "05yp740l58mw3dlaw09668avlr0i992j0i0bfcbvd8hll3imbg0n";
+    rev = "release/${rosdistro}/${pname}/${version}-0";
+    sha256 = "1gv9hka3mdrmigzznwbpbcgp2mdjfj2ya1y71yzq7smmm2flypqq";
   };
 
   propagatedBuildInputs = [ catkin ];

--- a/pkgs/development/ros-modules/rosgraph/default.nix
+++ b/pkgs/development/ros-modules/rosgraph/default.nix
@@ -7,7 +7,9 @@
 
 let
   pname = "rosgraph";
-  version = "1.13.6";
+  version = "1.14.4";
+  rosdistro = "melodic";
+
 
 in mkRosPackage {
   name = "${pname}-${version}";
@@ -15,8 +17,8 @@ in mkRosPackage {
   src = fetchFromGitHub {
     owner = "ros-gbp";
     repo = "ros_comm-release";
-    rev = "release/lunar/${pname}/${version}-0";
-    sha256 = "18yz5wwc8l16zc7n7jxj5qq7bpby00wmdvf1687dw8qrq3nlxqq6";
+    rev = "release/${rosdistro}/${pname}/${version}-0";
+    sha256 = "1n4smqb0j2yjrinj13j7wc43mysrl9ivya7wv6qg8fbbpx6s1xdc";
   };
 
   propagatedBuildInputs = [ catkin python3Packages.netifaces ];

--- a/pkgs/development/ros-modules/rosgraph_msgs/default.nix
+++ b/pkgs/development/ros-modules/rosgraph_msgs/default.nix
@@ -10,6 +10,7 @@
 let
   pname = "rosgraph_msgs";
   version = "1.11.2";
+  rosdistro = "melodic";
 
 in mkRosPackage {
   name = "${pname}-${version}";
@@ -17,7 +18,7 @@ in mkRosPackage {
   src = fetchFromGitHub {
     owner = "ros-gbp";
     repo = "ros_comm_msgs-release";
-    rev = "release/lunar/${pname}/${version}-0";
+    rev = "release/${rosdistro}/${pname}/${version}-0";
     sha256 = "1acyvalskr9hk23g2rsavpanjvnhq1cz467lnymyh4xd5g7xkrza";
   };
 

--- a/pkgs/development/ros-modules/roslang/default.nix
+++ b/pkgs/development/ros-modules/roslang/default.nix
@@ -6,7 +6,8 @@
 
 let
   pname = "roslang";
-  version = "1.14.1";
+  version = "1.14.4";
+  rosdistro = "melodic";
 
 in mkRosPackage {
   name = "${pname}-${version}";
@@ -14,8 +15,8 @@ in mkRosPackage {
   src = fetchFromGitHub {
     owner = "ros-gbp";
     repo = "ros-release";
-    rev = "release/lunar/${pname}/${version}-0";
-    sha256 = "04hj3qv0gyc9ld0pyxjmw54y6jxag5x5dg864zc1jah09mz3sxvh";
+    rev = "release/${rosdistro}/${pname}/${version}-0";
+    sha256 = "18p5ncr4qq3shhmrf3zsmx7sqpzli2n2k9lbb1s64fqljcwnzkd1";
   };
 
   propagatedBuildInputs = [ catkin ];

--- a/pkgs/development/ros-modules/roslaunch/default.nix
+++ b/pkgs/development/ros-modules/roslaunch/default.nix
@@ -14,7 +14,8 @@
 
 let
   pname = "roslaunch";
-  version = "1.13.6";
+  version = "1.14.4";
+  rosdistro = "melodic";
 
 in mkRosPackage {
   name = "${pname}-${version}";
@@ -22,8 +23,8 @@ in mkRosPackage {
   src = fetchFromGitHub {
     owner = "ros-gbp";
     repo = "ros_comm-release";
-    rev = "release/lunar/${pname}/${version}-0";
-    sha256 = "08rz1xxj7703sqrnfa8sww6jxm0k8jx10c7qsa23c3m63v0gm06n";
+    rev = "release/${rosdistro}/${pname}/${version}-0";
+    sha256 = "17nqv4i54s5wsx9nsmn3q2yr88rfmdhvz1sg91fdl79wg7w6vq00";
   };
 
   propagatedBuildInputs = [ catkin rosclean rosgraph_msgs roslib

--- a/pkgs/development/ros-modules/roslz4/default.nix
+++ b/pkgs/development/ros-modules/roslz4/default.nix
@@ -7,7 +7,8 @@
 
 let
   pname = "roslz4";
-  version = "1.13.6";
+  version = "1.14.4";
+  rosdistro = "melodic";
 
 in mkRosPackage {
   name = "${pname}-${version}";
@@ -15,8 +16,8 @@ in mkRosPackage {
   src = fetchFromGitHub {
     owner = "ros-gbp";
     repo = "ros_comm-release";
-    rev = "release/lunar/${pname}/${version}-0";
-    sha256 = "1gffgknj3msb8n57pd31h3nly6rz2z7ymm660mxqmj7b4kfbdlbv";
+    rev = "release/${rosdistro}/${pname}/${version}-0";
+    sha256 = "1f3ar4jpmmv9w8rgf4hdyp4vdhly01ym3pc2faaacf6lcyxzrmcn";
   };
 
   propagatedBuildInputs = [ catkin lz4 ];

--- a/pkgs/development/ros-modules/rosmake/default.nix
+++ b/pkgs/development/ros-modules/rosmake/default.nix
@@ -6,7 +6,8 @@
 
 let
   pname = "rosmake";
-  version = "1.14.1";
+  version = "1.14.4";
+  rosdistro = "melodic";
 
 in mkRosPackage {
   name = "${pname}-${version}";
@@ -14,8 +15,8 @@ in mkRosPackage {
   src = fetchFromGitHub {
     owner = "ros-gbp";
     repo = "ros-release";
-    rev = "release/lunar/${pname}/${version}-0";
-    sha256 = "0fr1a2r2j5gz2l9nfy9ajnn70gw9mmrl14k6ch9kn554iskyj99a";
+    rev = "release/${rosdistro}/${pname}/${version}-0";
+    sha256 = "0kk49a5xmlp4dv90rzf22kz5yjn4dw67lny6rss2qsanpr01zgmy";
   };
 
   propagatedBuildInputs = [ catkin ];

--- a/pkgs/development/ros-modules/rosmaster/default.nix
+++ b/pkgs/development/ros-modules/rosmaster/default.nix
@@ -7,7 +7,8 @@
 
 let
   pname = "rosmaster";
-  version = "1.13.6";
+  version = "1.14.4";
+  rosdistro = "melodic";
 
 in mkRosPackage {
   name = "${pname}-${version}";
@@ -15,8 +16,8 @@ in mkRosPackage {
   src = fetchFromGitHub {
     owner = "ros-gbp";
     repo = "ros_comm-release";
-    rev = "release/lunar/${pname}/${version}-0";
-    sha256 = "0w738zfvhqcizpm613niblsrs0c0wwjb1hss1r9n1kqpp5qrh7m8";
+    rev = "release/${rosdistro}/${pname}/${version}-0";
+    sha256 = "0c522317g8kfmx90krhy83znvlhkm836gwbdl478jn6fm1xrs90h";
   };
 
   propagatedBuildInputs = [ catkin rosgraph ];

--- a/pkgs/development/ros-modules/rosmsg/default.nix
+++ b/pkgs/development/ros-modules/rosmsg/default.nix
@@ -9,7 +9,8 @@
 
 let
   pname = "rosmsg";
-  version = "1.13.6";
+  version = "1.14.4";
+  rosdistro = "melodic";
 
 in mkRosPackage {
   name = "${pname}-${version}";
@@ -17,8 +18,8 @@ in mkRosPackage {
   src = fetchFromGitHub {
     owner = "ros-gbp";
     repo = "ros_comm-release";
-    rev = "release/lunar/${pname}/${version}-0";
-    sha256 = "0cbxjppj5s40llz08pwkqp7mwcsmpd9qyncb8f74xi7pgpdh2pdr";
+    rev = "release/${rosdistro}/${pname}/${version}-0";
+    sha256 = "058b8blzrmvxnjq07dyhzifgwvabah5bkfzxyp90cd0rvijxnfkj";
   };
 
   propagatedBuildInputs = [ catkin genmsg rosbag roslib ];

--- a/pkgs/development/ros-modules/rosnode/default.nix
+++ b/pkgs/development/ros-modules/rosnode/default.nix
@@ -8,7 +8,9 @@
 
 let
   pname = "rosnode";
-  version = "1.13.6";
+  version = "1.14.4";
+  rosdistro = "melodic";
+
 
 in mkRosPackage {
   name = "${pname}-${version}";
@@ -16,8 +18,8 @@ in mkRosPackage {
   src = fetchFromGitHub {
     owner = "ros-gbp";
     repo = "ros_comm-release";
-    rev = "release/lunar/${pname}/${version}-0";
-    sha256 = "0f3m6ndmzdlj7cgxzcg0m5jk3sl2kc3jj92jb2631n5h4fw6ix2v";
+    rev = "release/${rosdistro}/${pname}/${version}-0";
+    sha256 = "0prsfdvnh17d0ig3gz25k0zif0gbdc80fwy0s6z4ffn97nap6sd0";
   };
 
   propagatedBuildInputs = [ catkin rosgraph rostopic ];

--- a/pkgs/development/ros-modules/rosout/default.nix
+++ b/pkgs/development/ros-modules/rosout/default.nix
@@ -8,7 +8,8 @@
 
 let
   pname = "rosout";
-  version = "1.13.6";
+  version = "1.14.4";
+  rosdistro = "melodic";
 
 in mkRosPackage {
   name = "${pname}-${version}";
@@ -16,8 +17,8 @@ in mkRosPackage {
   src = fetchFromGitHub {
     owner = "ros-gbp";
     repo = "ros_comm-release";
-    rev = "release/lunar/${pname}/${version}-0";
-    sha256 = "1zkh1ds7174acssvm7b4r3ai6k7gwxsq469lif5m91ss8vr3dy5f";
+    rev = "release/${rosdistro}/${pname}/${version}-0";
+    sha256 = "0jvg35axm9b0wnckyff85l9kf7016z5kh95fb6qisk00j4h0pk4z";
   };
 
   propagatedBuildInputs = [ catkin roscpp rosgraph_msgs ];

--- a/pkgs/development/ros-modules/rosparam/default.nix
+++ b/pkgs/development/ros-modules/rosparam/default.nix
@@ -7,7 +7,8 @@
 
 let
   pname = "rosparam";
-  version = "1.13.6";
+  version = "1.14.4";
+  rosdistro = "melodic";
 
 in mkRosPackage {
   name = "${pname}-${version}";
@@ -15,8 +16,8 @@ in mkRosPackage {
   src = fetchFromGitHub {
     owner = "ros-gbp";
     repo = "ros_comm-release";
-    rev = "release/lunar/${pname}/${version}-0";
-    sha256 = "0b9gl8ril21x1ccnvwjimyrj4cq3cglsjhmkagrbdcw2vwrsd9js";
+    rev = "release/${rosdistro}/${pname}/${version}-0";
+    sha256 = "1nlg3xjn82svhcmrr5vyshkbf4f4c4mdcxwi2lcxzgzcl7rwid4w";
   };
 
   propagatedBuildInputs = [ catkin rosgraph ];

--- a/pkgs/development/ros-modules/rospy/default.nix
+++ b/pkgs/development/ros-modules/rospy/default.nix
@@ -12,7 +12,8 @@
 
 let
   pname = "rospy";
-  version = "1.13.6";
+  version = "1.14.4";
+  rosdistro = "melodic";
 
 in mkRosPackage {
   name = "${pname}-${version}";
@@ -20,8 +21,8 @@ in mkRosPackage {
   src = fetchFromGitHub {
     owner = "ros-gbp";
     repo = "ros_comm-release";
-    rev = "release/lunar/${pname}/${version}-0";
-    sha256 = "03gm4khik8s80diph826r1wjsdqfrgfky9cxfzzmjb0zd7qgj60d";
+    rev = "release/${rosdistro}/${pname}/${version}-0";
+    sha256 = "0xd7fzh52x7sd929lifxk0j6kb9ni0703ax6w59rm4r8bjhvpfv8";
   };
 
   propagatedBuildInputs = [ catkin genpy roscpp rosgraph rosgraph_msgs roslib std_msgs ];

--- a/pkgs/development/ros-modules/rosservice/default.nix
+++ b/pkgs/development/ros-modules/rosservice/default.nix
@@ -11,7 +11,8 @@
 
 let
   pname = "rosservice";
-  version = "1.13.6";
+  version = "1.14.4";
+  rosdistro = "melodic";
   
 in mkRosPackage {
   name = "${pname}-${version}";
@@ -19,8 +20,8 @@ in mkRosPackage {
   src = fetchFromGitHub {
     owner = "ros-gbp";
     repo = "ros_comm-release";
-    rev = "release/lunar/${pname}/${version}-0";
-    sha256 = "110n85fvr9lmg7jij07fi1arwi596zhsg4j0f1ibjp06p9dg0jgw";
+    rev = "release/${rosdistro}/${pname}/${version}-0";
+    sha256 = "0bwfvjkf33ykwkv01a3mjs38wp3q93cj2hkvghxlqn60x0hlddnp";
   };
 
   propagatedBuildInputs = [ catkin genpy rosgraph roslib rosmsg rospy ];

--- a/pkgs/development/ros-modules/rostest/default.nix
+++ b/pkgs/development/ros-modules/rostest/default.nix
@@ -11,7 +11,7 @@
 
 let
   pname = "rostest";
-  version = "1.13.6";
+  version = "1.14.4";
   rosdistro = "melodic";
 
 in mkRosPackage {
@@ -21,7 +21,7 @@ in mkRosPackage {
     owner = "ros-gbp";
     repo = "ros_comm-release";
     rev = "release/${rosdistro}/${pname}/${version}-0";
-    sha256 = "0n33dz7p2h9wpxmwry3p486jbwq8c3akjdzqgx6l83mb1yxg98fv";
+    sha256 = "0hvgg9l5dnp0cwd6c9hv19n9c07hjw3kz2j4j9j4nsg3m1dpsl56";
   };
 
   propagatedBuildInputs = [ catkin rosgraph roslaunch rosmaster rospy rosunit ];

--- a/pkgs/development/ros-modules/rostopic/default.nix
+++ b/pkgs/development/ros-modules/rostopic/default.nix
@@ -10,7 +10,8 @@
 
 let
   pname = "rostopic";
-  version = "1.13.6";
+  version = "1.14.4";
+  rosdistro = "melodic";
 
 in mkRosPackage {
   name = "${pname}-${version}";
@@ -18,8 +19,8 @@ in mkRosPackage {
   src = fetchFromGitHub {
     owner = "ros-gbp";
     repo = "ros_comm-release";
-    rev = "release/lunar/${pname}/${version}-0";
-    sha256 = "1r9hjmn47n2pmhbr0la3b4g6c0d4myww50z9m8x5dbl347kbqc7q";
+    rev = "release/${rosdistro}/${pname}/${version}-0";
+    sha256 = "10vnn8pvcsav1hzarsv8nqfd57z63lfhhc3fcxhjf76yg2p1nv1q";
   };
 
   propagatedBuildInputs = [ catkin genpy rosbag rospy rostest ];

--- a/pkgs/development/ros-modules/roswtf/default.nix
+++ b/pkgs/development/ros-modules/roswtf/default.nix
@@ -13,7 +13,8 @@
 
 let
   pname = "roswtf";
-  version = "1.13.6";
+  version = "1.14.4";
+  rosdistro = "melodic";
 
 in mkRosPackage {
   name = "${pname}-${version}";
@@ -21,8 +22,8 @@ in mkRosPackage {
   src = fetchFromGitHub {
     owner = "ros-gbp";
     repo = "ros_comm-release";
-    rev = "release/lunar/${pname}/${version}-0";
-    sha256 = "057zpghy8vdnqxacaz9zq7s8rbyjy1qa9ynf6mh5dnyidl7861hd";
+    rev = "release/${rosdistro}/${pname}/${version}-0";
+    sha256 = "18adra8af2vjivpplngr02bpmhzv5njn1rzbxmzbab554yswf791";
   };
 
   propagatedBuildInputs = [ catkin rosbuild rosgraph roslaunch roslib rosnode rosservice rostest ];


### PR DESCRIPTION
###### Motivation for this change
update ros-modules to melodic rosdistro

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

