### PR TITLE
rosunit: fix print_report error

### DIFF
--- a/pkgs/development/ros-modules/rosunit/default.nix
+++ b/pkgs/development/ros-modules/rosunit/default.nix
@@ -20,6 +20,8 @@ in mkRosPackage {
     sha256 = "0czgdsy7acg32a6vhshfk61m8gqay1qv65v8i9fi4r4zc235d0sh";
   };
 
+  patches = [ ./print_report_stream_write_argument_type_fix.patch ];
+
   propagatedBuildInputs = [ catkin roslib ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ros-modules/rosunit/print_report_stream_write_argument_type_fix.patch
+++ b/pkgs/development/ros-modules/rosunit/print_report_stream_write_argument_type_fix.patch
@@ -1,0 +1,12 @@
+diff --git a/src/rosunit/xmlrunner.py b/src/rosunit/xmlrunner.py
+--- a/src/rosunit/xmlrunner.py
++++ b/src/rosunit/xmlrunner.py
+@@ -199,7 +199,7 @@
+         output and standard error streams must be passed in.a
+ 
+         """
+-        stream.write(ET.tostring(self.xml(time_taken, out, err).getroot(), encoding='utf-8', method='xml'))
++        stream.write(ET.tostring(self.xml(time_taken, out, err).getroot(), encoding='unicode', method='xml'))
+ 
+     def print_report_text(self, stream, time_taken, out, err):
+         """Prints the text report to the supplied stream.


### PR DESCRIPTION
###### Motivation for this change
fix error
```
Traceback (most recent call last):
  File "/nix/store/iwr0pcsgwaks20nv84aml85fls4fjlm9-rostest-1.14.4/bin/rostest", line 36, in <module>
    rostestmain()
  File "/nix/store/iwr0pcsgwaks20nv84aml85fls4fjlm9-rostest-1.14.4/lib/python3.6/site-packages/rostest/__init__.py", line 274, in rostestmain
    _main()
  File "/nix/store/iwr0pcsgwaks20nv84aml85fls4fjlm9-rostest-1.14.4/lib/python3.6/site-packages/rostest/rostest_main.py", line 171, in rostestmain
    result = xml_runner.run(suite)
  File "/nix/store/lwq07p1ikvnymj78zmyks64fbm8ip9ps-rosunit-1.14.4/lib/python3.6/site-packages/rosunit/xmlrunner.py", line 275, in run
    result.print_report(stream, time_taken, out_s, err_s)
  File "/nix/store/lwq07p1ikvnymj78zmyks64fbm8ip9ps-rosunit-1.14.4/lib/python3.6/site-packages/rosunit/xmlrunner.py", line 202, in print_report
    stream.write(ET.tostring(self.xml(time_taken, out, err).getroot(), encoding='utf-8', method='xml'))
TypeError: write() argument must be str, not bytes
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

