### PR TITLE
python-persistence-queue: init at 1.3.0

### DIFF
--- a/pkgs/applications/science/robotics/aira/robonomics_comm/default.nix
+++ b/pkgs/applications/science/robotics/aira/robonomics_comm/default.nix
@@ -18,7 +18,7 @@ mkRosPackage rec {
   };
 
   propagatedBuildInputs = with python3Packages;
-  [ ros_comm web3 multihash voluptuous ipfsapi ];
+  [ ros_comm web3 multihash voluptuous ipfsapi python-persistent-queue ];
 
   meta = with stdenv.lib; {
     description = "Robonomics communication stack";

--- a/pkgs/applications/science/robotics/aira/robonomics_dev/default.nix
+++ b/pkgs/applications/science/robotics/aira/robonomics_dev/default.nix
@@ -23,7 +23,7 @@ in mkRosPackage {
 
   propagatedBuildInputs = with python3Packages;
   [ ros_comm actionlib ros_opcua_communication ipfsapi
-    numpy web3 google_api_python_client voluptuous multihash
+    numpy web3 google_api_python_client voluptuous multihash python-persistent-queue
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/python-persistent-queue/default.nix
+++ b/pkgs/development/python-modules/python-persistent-queue/default.nix
@@ -1,0 +1,23 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "python_persistent_queue";
+  version = "1.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1lnr9i8sdhqpmn1jgcix8vslg2xzkprx2jbsq1lz5iyb2hi9zydw";
+  };
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Implementation of a persistent queue in Python. ";
+    homepage = "https://github.com/philipbl/python-persistent-queue";
+    license = licenses.mit;
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11076,6 +11076,8 @@ EOF
 
   multihash = callPackage ../development/python-modules/multihash { };
 
+  python-persistent-queue = callPackage ../development/python-modules/python-persistent-queue { };
+
   z3 = (toPythonModule (pkgs.z3.override {
     inherit python;
   })).python;


### PR DESCRIPTION
###### Motivation for this change
add python module with persistent queue implementation

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

