### PR TITLE
robonomics_comm: v0.4.1

### DIFF
--- a/pkgs/applications/science/robotics/aira/robonomics_comm/default.nix
+++ b/pkgs/applications/science/robotics/aira/robonomics_comm/default.nix
@@ -8,13 +8,13 @@
 mkRosPackage rec {
   name = "${pname}-${version}";
   pname = "robonomics_comm";
-  version = "0.4";
+  version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "airalab";
     repo = "robonomics_comm";
     rev = "v${version}";
-    sha256 = "092fm7ijd1hlws3rggihzidp054yyvw77sp2fji2l568a5raxk7z";
+    sha256 = "07qln00fm1zi6d52cmc6j66n00syy35ich3rjgdbxy0m0l903yxa";
   };
 
   propagatedBuildInputs = with python3Packages;


### PR DESCRIPTION
###### Motivation for this change
robonomics_comm update: 0.4.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

