### PR TITLE
erc20: add web3_ws_provider option

### DIFF
--- a/nixos/modules/services/robonomics/erc20.nix
+++ b/nixos/modules/services/robonomics/erc20.nix
@@ -47,6 +47,12 @@ in {
         description = "Web3 http provider address";
       };
 
+      web3_ws_provider = mkOption {
+        type = types.str;
+        default = "wss://mainnet.infura.io/ws";
+        description = "Web3 websocket provider address";
+      };
+
     };
   };
 
@@ -70,7 +76,8 @@ in {
               ens_contract:="${cfg.ens}" \
               keyfile:="${cfg.keyfile}" \
               keyfile_password_file:="${cfg.keyfile_password_file}" \
-              web3_http_provider:="${cfg.web3_http_provider}"
+              web3_http_provider:="${cfg.web3_http_provider}" \
+              web3_ws_provider:="${cfg.web3_ws_provider}"
       '';
 
       serviceConfig = {


### PR DESCRIPTION
###### Motivation for this change
add web3 websocket provider option (compatibility with robonomics_comm 0.4.1)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

