### PR TITLE
Update robonomics_tutorials

### DIFF
--- a/pkgs/applications/science/robotics/aira/robonomics_tutorials/default.nix
+++ b/pkgs/applications/science/robotics/aira/robonomics_tutorials/default.nix
@@ -8,13 +8,13 @@
 mkRosPackage rec {
   name = "${pname}-${version}";
   pname = "robonomics_tutorials";
-  version = "0.1.0";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "airalab";
     repo = pname;
     rev = "v${version}";
-    sha256 = "07zzkypy8mci8z59fzcads4zixlcfm1xm050y11fzxhc5815bq9q";
+    sha256 = "1w1q9lph0x1h2bpj4l1g7453hkrvdlpgi7aqwbvd9nf2360nadf8";
   };
 
   propagatedBuildInputs = [ robonomics_comm rosserial ];


### PR DESCRIPTION
###### Motivation for this change
robonomics_tutorials: v0.1.0 -> v0.2.0

Added a dapp folder for arduino_with_args lesson

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

