### PR TITLE
robonomics_tutorials: fix sha256 hash

### DIFF
--- a/pkgs/applications/science/robotics/aira/robonomics_tutorials/default.nix
+++ b/pkgs/applications/science/robotics/aira/robonomics_tutorials/default.nix
@@ -14,7 +14,7 @@ mkRosPackage rec {
     owner = "airalab";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1w1q9lph0x1h2bpj4l1g7453hkrvdlpgi7aqwbvd9nf2360nadf8";
+    sha256 = "14vbnnyrz394wnlp2m9zbav0izpadpgqb0h7s2pvzk6jrbc21zpz";
   };
 
   propagatedBuildInputs = [ robonomics_comm rosserial ];


### PR DESCRIPTION
###### Motivation for this change
robonomics_tutorials: wrong hash

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

