### PR TITLE
robonomics liability: fix tests

### DIFF
--- a/nixos/tests/liability.nix
+++ b/nixos/tests/liability.nix
@@ -125,10 +125,12 @@ in {
           web3_http_provider = "http://127.0.0.1:10545";
           web3_ws_provider = "ws://127.0.0.1:10546";
           lighthouse = "test.lighthouse.4.robonomics.eth";
+          factory = "factory.4.robonomics.eth";
           ens = "0x5F3DBa5e45909D1bf126aA0aF0601B1a369dbFD7";
           keyfile = "/etc/keys/LiabilityTest/user.keyfile";
           keyfile_password_file = "/etc/keys/user.psk";
-          enable_aira_graph = false;
+          graph_topic = "graph.4.robonomics.eth";
+          graph = false;
         };
 
         services.parity = {


### PR DESCRIPTION
###### Motivation for this change
fix liability service tests in accordance with the latest changes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

