### PR TITLE
add roscore service

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -663,6 +663,7 @@
   ./services/robonomics/liability.nix
   ./services/robonomics/erc20.nix
   ./services/robonomics/xrtd.nix
+  ./services/robonomics/roscore.nix
   ./services/scheduling/atd.nix
   ./services/scheduling/chronos.nix
   ./services/scheduling/cron.nix

--- a/nixos/modules/profiles/aira-foundation.nix
+++ b/nixos/modules/profiles/aira-foundation.nix
@@ -20,4 +20,10 @@ in {
     enable = true;
     inherit web3_http_provider web3_ws_provider token factory;
   };
+
+  # enable separated roscore nodes
+  services.roscore = {
+    enable = true;
+  };
+
 }

--- a/nixos/modules/profiles/aira-sidechain.nix
+++ b/nixos/modules/profiles/aira-sidechain.nix
@@ -21,4 +21,10 @@ in {
     enable = true;
     inherit ens web3_http_provider web3_ws_provider token factory;
   };
+
+  # enable separated roscore nodes
+  services.roscore = {
+    enable = true;
+  };
+
 }

--- a/nixos/modules/services/robonomics/erc20.nix
+++ b/nixos/modules/services/robonomics/erc20.nix
@@ -70,6 +70,7 @@ in {
     environment.systemPackages = with pkgs; [ robonomics_comm ];
 
     systemd.services.erc20 = {
+      wants = [ "roscore.service" ];
       wantedBy = [ "multi-user.target" ];
 
       preStart = ''

--- a/nixos/modules/services/robonomics/liability.nix
+++ b/nixos/modules/services/robonomics/liability.nix
@@ -104,7 +104,7 @@ in {
     };
 
     systemd.services.liability = {
-      wants = [ "ipfs.service" ];
+      wants = [ "ipfs.service" "roscore.service" ];
       wantedBy = [ "multi-user.target" ];
 
       environment.ROS_MASTER_URI = cfg.ros_master_uri;

--- a/nixos/modules/services/robonomics/roscore.nix
+++ b/nixos/modules/services/robonomics/roscore.nix
@@ -1,0 +1,47 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.roscore;
+
+  ros_master_port = 11311;
+
+in {
+  options = {
+    services.roscore = {
+      enable = mkEnableOption "Enable ROS Master, a ROS Parameter Server and a rosout logging node.";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.roslaunch;
+        defaultText = "pkgs.roslaunch";
+        description = "Tool for launching ROS nodes";
+      };
+
+      port = mkOption {
+        type = types.int;
+        default = ros_master_port;
+        description = "ROS master port";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.roscore = {
+      wantedBy = [ "multi-user.target" ];
+
+      script = ''
+        source ${cfg.package}/setup.bash \
+          && roscore -p ${toString cfg.port}
+      '';
+
+      serviceConfig = {
+        Restart = "on-failure";
+        RestartSec = 5;
+      };
+
+
+    };
+  };
+}


### PR DESCRIPTION
###### Motivation for this change
add separated roscore service for reusing by liability.service, erc20.service and so on
see airalab/aira#87

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

