### PR TITLE
fix aira services initialization order

### DIFF
--- a/nixos/modules/services/robonomics/erc20.nix
+++ b/nixos/modules/services/robonomics/erc20.nix
@@ -70,7 +70,8 @@ in {
     environment.systemPackages = with pkgs; [ robonomics_comm ];
 
     systemd.services.erc20 = {
-      wants = [ "roscore.service" ];
+      requires = [ "roscore.service" ];
+      after =    [ "roscore.service" "liability.service" ];
       wantedBy = [ "multi-user.target" ];
 
       preStart = ''

--- a/nixos/modules/services/robonomics/liability.nix
+++ b/nixos/modules/services/robonomics/liability.nix
@@ -104,7 +104,8 @@ in {
     };
 
     systemd.services.liability = {
-      wants = [ "ipfs.service" "roscore.service" ];
+      requires = [ "ipfs.service" "roscore.service" ];
+      after = [ "ipfs.service" "roscore.service" ];
       wantedBy = [ "multi-user.target" ];
 
       environment.ROS_MASTER_URI = cfg.ros_master_uri;


### PR DESCRIPTION
###### Motivation for this change
fix liability and erc20 services loading order 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

