### PR TITLE
fix erc20 and liability services initialization order

### DIFF
--- a/nixos/modules/services/robonomics/erc20.nix
+++ b/nixos/modules/services/robonomics/erc20.nix
@@ -71,7 +71,7 @@ in {
 
     systemd.services.erc20 = {
       requires = [ "roscore.service" ];
-      after =  [ "roscore.service" ];
+      after =    [ "roscore.service" "liability.service" ];
       wantedBy = [ "multi-user.target" ];
 
       preStart = ''


### PR DESCRIPTION
###### Motivation for this change
run erc20 after liability if enabled both

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

