### PR TITLE
robonomics_comm-nightly revision update + liability service tests updates

### DIFF
--- a/nixos/tests/liability.nix
+++ b/nixos/tests/liability.nix
@@ -73,9 +73,16 @@ reseal_on_txs = "none"
   ENS_address = "0x5F3DBa5e45909D1bf126aA0aF0601B1a369dbFD7";
 
   lighthouse_contract = "test.lighthouse.4.robonomics.eth";
+  factory_contract = "factory.4.robonomics.eth";
 
   keyfile = "/etc/keys/LiabilityTest/user.keyfile";
   keyfile_password_file = "/etc/keys/user.psk";
+
+  demand_signer_keyfile = "/etc/keys/LiabilityTest/authority.keyfile";
+  demand_signer_keyfile_password_file = "/etc/keys/authority.psk";
+
+  web3_http_provider = "http://127.0.0.1:10545";
+  web3_ws_provider = "ws://127.0.0.1:10546";
 
 in {
   name = "liability";
@@ -125,10 +132,10 @@ in {
         services.liability = {
           enable = true;
           package = package;
-          web3_http_provider = "http://127.0.0.1:10545";
-          web3_ws_provider = "ws://127.0.0.1:10546";
+          web3_http_provider = web3_http_provider;
+          web3_ws_provider = web3_ws_provider;
           lighthouse = lighthouse_contract;
-          factory = "factory.4.robonomics.eth";
+          factory = factory_contract;
           ens = ENS_address;
           keyfile = keyfile;
           keyfile_password_file = keyfile_password_file;
@@ -154,6 +161,7 @@ in {
 node0
 user'';
         environment.etc."keys/user.psk".text = ''user'';
+        environment.etc."keys/authority.psk".text = ''node0'';
 
         environment.etc."resolv.conf".text = "nameserver 8.8.8.8";
         environment.etc."liability-test-chain.json".text = chain_spec;
@@ -182,11 +190,11 @@ user'';
 
     #run xrtd. TODO: systemd service
     $liability_node->mustSucceed("
-      xrtd --private 3df8095dfbae93d8c7f1143b217a483d57a7f745e2542425dfe2fa25264cb2e8 --web3 http://localhost:10545 --ens ${ENS_address} --chain 8995 --lighthouse ${lighthouse_contract} > /tmp/xrtd.log 2>&1 &
+      xrtd --private ${user_account_private_key} --web3 ${web3_http_provider} --ens ${ENS_address} --chain 8995 --lighthouse ${lighthouse_contract} > /tmp/xrtd.log 2>&1 &
     ");
 
     $liability_node->mustSucceed("
-      source ${package}/setup.bash && rostest -r robonomics_liability liability.test keyfile:=${keyfile} keyfile_password_file:=${keyfile_password_file} ens_contract:=${ENS_address} lighthouse_contract:=${lighthouse_contract}  web3_http_provider:='http://127.0.0.1:10545'  test_token:=0xDfE46C9140819979D4d02297EC37DAa224f512f2 >&2
+      source ${package}/setup.bash && rostest -r robonomics_liability liability.test keyfile:=${keyfile} keyfile_password_file:=${keyfile_password_file} ens_contract:=${ENS_address} lighthouse_contract:=${lighthouse_contract}  web3_http_provider:=${web3_http_provider} test_token:=${XRT_address} factory_contract:=${factory_contract} demand_signer_keyfile:=${demand_signer_keyfile} demand_signer_keyfile_password_file:=${demand_signer_keyfile_password_file} >&2
     ");
   '';
 })

--- a/pkgs/applications/science/robotics/aira/robonomics_comm/nightly.nix
+++ b/pkgs/applications/science/robotics/aira/robonomics_comm/nightly.nix
@@ -7,8 +7,8 @@
 }:
 
 let
-  rev = "c9c830d4c1dce3950441d77fef448629f48fc709";
-  sha256 = "0vvvk30k9fr6b71ly46s2f7fxc5alrkf1njdj4sd4gkvfrf686qd";
+  rev = "73eaaa5493dc2088546755c18f83a7c0a26e7a3f";
+  sha256 = "0w4dldiyqxxr54v1sik0nm4962hwi5fg784b7885vsc6jxwgjkp6";
 
 in mkRosPackage rec {
   name = "${pname}-${version}";


### PR DESCRIPTION
###### Motivation for this change
update robonomics_comm-nightly revision

make liability service tests compatible with upcoming robonomics_comm

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

