### PR TITLE
add azure-agent python package

### DIFF
--- a/pkgs/development/python-modules/azure-agent/azure-agent-entropy.patch
+++ b/pkgs/development/python-modules/azure-agent/azure-agent-entropy.patch
@@ -1,0 +1,17 @@
+--- a/bin/waagent2.0	2019-05-17 04:20:00.728088851 +0200
++++ a/bin/waagent2.0	2019-05-17 04:20:00.572680025 +0200
+@@ -5678,10 +5678,10 @@
+             Log("MAC  address: " + ":".join(["%02X" % Ord(a) for a in mac]))
+         
+         # Consume Entropy in ACPI table provided by Hyper-V
+-        try:
+-            SetFileContents("/dev/random", GetFileContents("/sys/firmware/acpi/tables/OEM0"))
+-        except:
+-            pass
++        #try:
++        #    SetFileContents("/dev/random", GetFileContents("/sys/firmware/acpi/tables/OEM0"))
++        #except:
++        #    pass
+ 
+         Log("Probing for Azure environment.")
+         self.Endpoint = self.DoDhcpWork()

--- a/pkgs/development/python-modules/azure-agent/default.nix
+++ b/pkgs/development/python-modules/azure-agent/default.nix
@@ -1,0 +1,77 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, buildPythonPackage
+, findutils
+, gnugrep
+, gawk
+, coreutils
+, openssl
+, openssh
+, nettools
+, procps
+, shadow
+, utillinux
+, parted
+, python
+, python3Packages
+, makeWrapper
+, mock
+, nose
+, pytest
+}:
+
+with lib;
+
+buildPythonPackage rec {
+  pname   = "azure-agent";
+  version = "2.2.40";
+
+  patches = [ ./azure-agent-entropy.patch ];
+
+  src = fetchFromGitHub {
+    owner  = "Azure";
+    repo   = "WALinuxAgent";
+    rev    = "v${version}";
+    sha256 = "14hpw9lkkia7gdl301fryjr7pyh3hrbb83dcpqnr31caqi8ywlyr";
+  };
+
+  doCheck = false;
+
+  buildInputs = [ makeWrapper python python3Packages.wrapPython python3Packages.distro];
+  runtimeDeps = [ findutils gnugrep gawk coreutils openssl openssh
+                    nettools # for hostname
+                    procps # for pidof
+                    shadow # for useradd, usermod
+                    utillinux # for (u)mount, fdisk, sfdisk, mkswap
+                    parted
+                ];
+  pythonPath = [ python3Packages.pyasn1 ];
+
+  checkInputs = [ pytest mock nose];
+  postPatch = ''
+      substituteInPlace config/66-azure-storage.rules  --replace /bin/sh "${stdenv.shell}"
+      substituteInPlace config/99-azure-product-uuid.rules --replace /bin/chmod "${coreutils}/bin/chmod"
+      substituteInPlace tests/test_agent.py --replace /usr/bin/openssl ${openssl}/bin/openssl
+      substituteInPlace tests/common/test_conf.py --replace /usr/bin/openssl ${openssl}/bin/openssl
+      substituteInPlace azurelinuxagent/common/conf.py --replace /usr/bin/openssl ${openssl}/bin/openssl
+  '';
+
+  postInstall = ''
+    install -dm755 "$out/lib/udev/rules.d"
+    install -m644 config/*.rules "$out/lib/udev/rules.d"
+    mv bin $out/bin/
+    wrapProgram "$out/bin/waagent" \
+        --prefix PYTHONPATH : $PYTHONPATH \
+        --prefix PATH : "${makeBinPath runtimeDeps}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Microsoft Azure Linux Guest Agent http://azure.microsoft.com/";
+    homepage    = "https://github.com/Azure/WALinuxAgent/";
+    license     = licenses.asl20;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ spd ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -239,6 +239,8 @@ in {
 
   azure = callPackage ../development/python-modules/azure { };
 
+  azure-agent  = callPackage ../development/python-modules/azure-agent { };
+
   azure-nspkg = callPackage ../development/python-modules/azure-nspkg { };
 
   azure-common = callPackage ../development/python-modules/azure-common { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
