### PR TITLE
web3 python module: ignore network in normalizers

### DIFF
--- a/pkgs/development/python-modules/web3/default.nix
+++ b/pkgs/development/python-modules/web3/default.nix
@@ -22,7 +22,7 @@ in buildPythonPackage rec {
     sha256 = "1m4jf1s0f71r42h3j7vpp2szpwq9kbsrlvdz5dcs5rwwlndjpxqw";
   };
 
-  patches = [ ./append-sid-tld.patch ];
+  patches = [ ./append-sid-tld.patch ./normalizer-ignore-network.patch ];
 
   propagatedBuildInputs = [ lru-dict requests eth-abi eth-account websockets6 ];
 

--- a/pkgs/development/python-modules/web3/normalizer-ignore-network.patch
+++ b/pkgs/development/python-modules/web3/normalizer-ignore-network.patch
@@ -1,0 +1,15 @@
+--- a/web3/utils/normalizers.py	2019-08-23 14:39:41.263079574 +0300
++++ b/web3/utils/normalizers.py	2019-08-23 14:40:04.809324547 +0300
+@@ -144,10 +144,9 @@
+                 "Could not look up name %r because ENS is"
+                 " set to None" % (val)
+             )
+-        elif int(w3.net.version) is not 1 and not isinstance(w3.ens, StaticENS):
++        elif isinstance(w3.ens, StaticENS):
+             raise InvalidAddress(
+-                "Could not look up name %r because web3 is"
+-                " not connected to mainnet" % (val)
++                "Could not look up name %r because web3 ens is StaticENS" % (val)
+             )
+         else:
+             return (abi_type, validate_name_has_address(w3.ens, val))


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
