### PR TITLE
First services

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -734,6 +734,9 @@
   ./services/robonomics/erc20.nix
   ./services/robonomics/xrtd.nix
   ./services/robonomics/roscore.nix
+  ./services/robonomics/issuing-service.nix
+  ./services/robonomics/drone_passport.nix
+  ./services/robonomics/drone_flight_report.nix
   ./services/scheduling/atd.nix
   ./services/scheduling/chronos.nix
   ./services/scheduling/cron.nix

--- a/nixos/modules/services/robonomics/drone_flight_report.nix
+++ b/nixos/modules/services/robonomics/drone_flight_report.nix
@@ -1,0 +1,58 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.drone_passport;
+
+  operationalToken = "0x7dE91B204C1C737bcEe6F000AAA6569Cf7061cb7";
+
+in {
+  options = {
+    services.drone_flight_report = {
+      enable = mkEnableOption "Enable Drone Flight Report service.";
+
+      lighthouse = mkOption {
+        type = types.str;
+        default = "0xA02500497E5163DbC049453509Fae8C9825cf18e";
+        description = "Lighthouse to work on";
+      };
+
+      token = mkOption {
+        type = types.str;
+        default = operationalToken;
+        description = "Operational token";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "liability";
+        description = "User account under which service runs.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = with pkgs; [ drone_flight_report ];
+
+    systemd.services.drone_passport = {
+      requires = [ "roscore.service"  ];
+      after = [ "liability.service" "roscore.service" ];
+      wantedBy = [ "multi-user.target" ];
+
+      script = ''
+        source ${pkgs.drone_flight_report}/setup.bash \
+          && roslaunch drone_flight_report agent.launch \
+              lighthouse:="${cfg.lighthouse}" \
+              token:="${cfg.token}"
+      '';
+
+      serviceConfig = {
+        Restart = "on-failure";
+        StartLimitInterval = 0;
+        RestartSec = 60;
+        User = cfg.user;
+      };
+    };
+  };
+}

--- a/nixos/modules/services/robonomics/drone_passport.nix
+++ b/nixos/modules/services/robonomics/drone_passport.nix
@@ -1,0 +1,72 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.drone_passport;
+
+  operationalToken = "0x966EbbFD7ECbCF44b1e05341976e0652CFA01360";
+
+in {
+  options = {
+    services.drone_passport = {
+      enable = mkEnableOption "Enable Drone Passport service.";
+
+      login = mkOption {
+        type = types.str;
+        default = "";
+        description = "Email sender login";
+      };
+
+      email_from = mkOption {
+        type = types.str;
+        default = "";
+        description = "The value of 'from' field in an email";
+      };
+
+      email_password = mkOption {
+        type = types.str;
+        default = "";
+        description = "Email password";
+      };
+
+      token = mkOption {
+        type = types.str;
+        default = operationalToken;
+        description = "Operational token";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "liability";
+        description = "User account under which service runs.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = with pkgs; [ drone_passport_agent ];
+
+    systemd.services.drone_passport = {
+      requires = [ "roscore.service"  ];
+      after = [ "liability.service" "roscore.service" ];
+      wantedBy = [ "multi-user.target" ];
+
+      script = ''
+        source ${pkgs.drone_passport_agent}/setup.bash \
+          && roslaunch drone_passport_agent agent.launch \
+              login:="${cfg.login}" \
+              email_from:="${cfg.email_from}" \
+              email_password:="${cfg.email_password}" \
+              token:="${cfg.token}"
+      '';
+
+      serviceConfig = {
+        Restart = "on-failure";
+        StartLimitInterval = 0;
+        RestartSec = 60;
+        User = cfg.user;
+      };
+    };
+  };
+}

--- a/nixos/modules/services/robonomics/issuing-service.nix
+++ b/nixos/modules/services/robonomics/issuing-service.nix
@@ -1,0 +1,76 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.issuing-service;
+
+  emitterContractAddress = "0x4b255d6E57409232F7C29759D5699dabE66f8Cd5";
+  validatorContractAddress = "0x8a919cC91bA1ac88BF5FdCeb116c35f7Dc1Ed179";
+
+  python-eth_keyfile = pkgs.python3.withPackages (ps : with ps; [ eth-keyfile ]);
+
+in {
+  options = {
+    services.issuing-service = {
+      enable = mkEnableOption "Enable Issuing service.";
+
+      emitter_contract = mkOption {
+        type = types.str;
+        default = emitterContractAddress;
+        description = "Emitter smart-contract address";
+      };
+
+      validator = mkOption {
+        type = types.str;
+        default = validatorContractAddress;
+        description = "Validator smart-contract address.";
+      };
+
+      lighthouse = mkOption {
+        type = types.str;
+        default = "0x2442ED30381f8556e1e2C12fdb0E7F0aa56192E9";
+        description = "Lighthouse address to work on";
+      };
+
+      token = mkOption {
+        type = types.str;
+        default = "0x7dE91B204C1C737bcEe6F000AAA6569Cf7061cb7";
+        description = "Payment token";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "liability";
+        description = "User account under which service runs.";
+      };
+
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = with pkgs; [ issuing_service_agent ];
+
+    systemd.services.erc20 = {
+      requires = [ "roscore.service" ];
+      after =    [ "roscore.service" "liability.service" ];
+      wantedBy = [ "multi-user.target" ];
+
+      script = ''
+        source ${pkgs.issuing_service_agent}/setup.bash \
+          && roslaunch issuing_service_agent issuer.launch \
+              emitter_contract:="${cfg.emitter_contract}" \
+              validator:="${cfg.validator}" \
+              lighthouse:="${cfg.lighthouse}" \
+              token:="${cfg.token}"
+      '';
+
+      serviceConfig = {
+        Restart = "on-failure";
+        StartLimitInterval = 0;
+        RestartSec = 60;
+        User = cfg.user;
+      };
+    };
+  };
+}

--- a/pkgs/applications/science/robotics/aira/drone_flight_report/default.nix
+++ b/pkgs/applications/science/robotics/aira/drone_flight_report/default.nix
@@ -8,20 +8,20 @@
 mkRosPackage rec {
   name = "${pname}-${version}";
   pname = "drone_flight_report";
-  version = "master";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
-    owner = "Vourhey";
+    owner = "DistributedSky";
     repo = "${pname}";
-    rev = "5cff6ef99989172f0ca0e5f6933e1e91538c2a18";
-    sha256 = "sha256:1h7yka9lcyddi5nivg3zq9bz9hvi2c3hi9q105m8m3qp1mq5i1gy";
+    rev = "bb51e628e50552cc065b2a782ab1936f787d34f5";
+    sha256 = "sha256:0n0dcqx1z9kfbmznfk2nxcdil55sskay170xh1q23q38r1djlkrs";
   };
 
   propagatedBuildInputs = [ robonomics_comm ];
 
   meta = with stdenv.lib; {
     description = "Service to register a drone flight via Robonmics Network";
-    homepage = http://github.com/vourhey/drone_flight_report;
+    homepage = http://github.com/DistributedSky/drone_flight_report;
     license = licenses.bsd3;
     maintainers = with maintainers; [ vourhey ];
   };

--- a/pkgs/applications/science/robotics/aira/drone_passport_agent/default.nix
+++ b/pkgs/applications/science/robotics/aira/drone_passport_agent/default.nix
@@ -7,20 +7,20 @@
 
 mkRosPackage rec {
   name = "${pname}-${version}";
-  pname = "de_direct";
-  version = "master";
+  pname = "drone_passport_agent";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
-    owner = "airalab";
+    owner = "DistributedSky";
     repo = "${pname}";
-    rev = "a4ee07ffd9a67d805464047ad48a3ed407d8fe34";
-    sha256 = "sha256:1sj6n2jix5a48c0q2bkis9bmqhix4mbqps9v5569kwwgyrw62f2b";
+    rev = "c783b73d4c184bd1a3c94df31ac4703d768ae319";
+    sha256 = "sha256:1lmpmf0ng0l3cjh090fzhvbazdr48zkwflz5znvjbj4fs7mi067m";
   };
   propagatedBuildInputs = [ robonomics_comm pkgs.python37Packages.flask-restful ];
 
   meta = with stdenv.lib; {
-    description = "DE direct";
-    homepage = http://github.com/airalab/de_direct;
+    description = "ROS-enabled drone passport agent";
+    homepage = http://github.com/DistributedSky/drone_passport_agent;
     license = licenses.bsd3;
     maintainers = [ maintainers.vourhey ];
   };

--- a/pkgs/applications/science/robotics/aira/issuing_service_agent/default.nix
+++ b/pkgs/applications/science/robotics/aira/issuing_service_agent/default.nix
@@ -8,20 +8,20 @@
 mkRosPackage rec {
   name = "${pname}-${version}";
   pname = "issuing-service-agent";
-  version = "master";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "DAO-IPCI";
-    repo = "issuing-service-package";
-    rev = "e38edc1dcb6e681f6ba8395db909d896248f9a21";
-    sha256 = "sha256:1z1xbdwbv51maqqqn0yhs72ry7rpvrvlavd5q7kjpn6x95y0knbl";
+    repo = "issuing_agent";
+    rev = "628537d4d621b399031d25e35f4ad27ab04073b9";
+    sha256 = "sha256:0mz87i6703kmcmjvdx1wqwpy2zr896y6hqpz5p7kgqrk2pdwpnab";
   };
 
   propagatedBuildInputs = [ robonomics_comm ];
 
   meta = with stdenv.lib; {
     description = "The agent is responsible for checking the data and issuing the green certificates";
-    homepage = http://github.com/DAO-IPCI/issuing-service-package;
+    homepage = http://github.com/DAO-IPCI/issuing_agent;
     license = licenses.bsd3;
     maintainers = with maintainers; [ vourhey ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25052,7 +25052,7 @@ in
 
   robonomics_dev = callPackage ../applications/science/robotics/aira/robonomics_dev { };
 
-  de_direct = callPackage ../applications/science/robotics/aira/de_direct {  };
+  drone_passport_agent = callPackage ../applications/science/robotics/aira/drone_passport_agent {  };
 
   drone_flight_report = callPackage ../applications/science/robotics/aira/drone_flight_report {  };
 


### PR DESCRIPTION
* Drone Flight Report: 0.4.0
* Drone Passport: 0.2.0
* Issuing Service: 0.2.0

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
