### PR TITLE
Update ipfs-subscriber.nix

### DIFF
--- a/nixos/modules/services/robonomics/ipfs-subscriber.nix
+++ b/nixos/modules/services/robonomics/ipfs-subscriber.nix
@@ -33,25 +33,39 @@ in {
         default = "";
         description = "ENS registry address";
       };
+      sid = {
+        enable = mkOption {
 
-    };
-  };
+          partOf = optional cfg.sid.enable "ipfs-subscriber-sid.service" ;
+          wantedBy = [ "multi-user.target" ];
 
-  config = mkIf cfg.enable {
-    systemd.services.ipfs-subscriber = {
-      requires = [ "ipfs.service" ];
-      after = [ "ipfs.service" ];
-      wantedBy = [ "multi-user.target" ];
+          path = with pkgs; [ bash getent ipfs ];
 
-      path = with pkgs; [ bash getent ipfs ];
+          script = ''
+            ${pkgs.robonomics-tools}/bin/ipfs-subscriber ${optionalString (cfg.web3_provider != "") "--web3 \"${cfg.web3_provider}\""} ${optionalString (cfg.ipfs_provider != "") "--ipfs \"${cfg.ipfs_provider}\""} ${optionalString (cfg.factory!= "") "--factory \"${cfg.factory}\""} ${optionalString (cfg.ens != "") "--ens \"${cfg.ens}\""} 
+          '';
 
-      script = ''
-        ${pkgs.robonomics-tools}/bin/ipfs-subscriber ${optionalString (cfg.web3_provider != "") "--web3 \"${cfg.web3_provider}\""} ${optionalString (cfg.ipfs_provider != "") "--ipfs \"${cfg.ipfs_provider}\""} ${optionalString (cfg.factory!= "") "--factory \"${cfg.factory}\""} ${optionalString (cfg.ens != "") "--ens \"${cfg.ens}\""} 
-      '';
+          serviceConfig = {
+            Restart = "on-failure";
+            RestartSec = 5;
+          };
+        };
+        ipfs-subscriber-sid = mkIf cfg.sid.enable {
+          requires = [ "ipfs.service" "ipfs-subscriber.service" ];
+          after = [ "ipfs.service" ];
+          wantedBy = [ "multi-user.target" ];
 
-      serviceConfig = {
-        Restart = "on-failure";
-        RestartSec = 5;
+          path = with pkgs; [ bash getent ipfs ];
+
+          script = ''
+            ${pkgs.robonomics-tools}/bin/ipfs-subscriber ${optionalString (cfg.sid.web3_provider != "") "--web3 \"${cfg.sid.web3_provider}\""} ${optionalString (cfg.sid.ipfs_provider != "") "--ipfs \"${cfg.sid.ipfs_provider}\""} ${optionalString (cfg.sid.factory!= "") "--factory \"${cfg.sid.factory}\""} ${optionalString (cfg.sid.ens != "") "--ens \"${cfg.sid.ens}\""} 
+          '';
+
+          serviceConfig = {
+            Restart = "on-failure";
+            RestartSec = 5;
+          };
+        };
       };
     };
   };


### PR DESCRIPTION


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

added the ability to launch a second unit for side chain subscriptions

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
