### PR TITLE
add build aira-sd-image-rpi4

### DIFF
--- a/nixos/modules/installer/cd-dvd/aira-sd-image-rpi4.nix
+++ b/nixos/modules/installer/cd-dvd/aira-sd-image-rpi4.nix
@@ -1,0 +1,86 @@
+{ config, lib, pkgs, ... }:
+{
+  imports = [
+    ../../profiles/base.nix
+    ../../profiles/clone-config.nix
+    ./sd-image.nix
+  ];
+  nixpkgs.config = { allowUnfree = true; };
+  hardware.firmware = [ pkgs.raspberrypiWirelessFirmware ];
+  fileSystems = {
+    "/boot" = {
+      device = "/dev/disk/by-label/FIRMWARE";
+      fsType = "vfat";
+    };
+    "/" = {
+      device = "/dev/disk/by-label/NIXOS_SD";
+      fsType = "ext4";
+    };
+  };
+  boot = {
+    loader = {
+      grub.enable = false;
+      raspberryPi = {
+        enable = true;
+        version = 4;
+      };
+    };
+    kernelPackages = pkgs.linuxPackages_rpi4;
+    kernelParams = [ "cma=256M" "console=ttyS0,115200n8" "console=ttyAMA0,115200n8" "console=tty0" ];
+    initrd.kernelModules =  [ "w1-gpio" "w1-therm" ];
+    consoleLogLevel = lib.mkDefault 7;
+  };
+  networking = {
+    hostName = "aira-rpi4";
+    wireless = {
+      enable = true;  # Enables wireless support via wpa_supplicant.
+      networks = {
+        Aira = { psk = "airapassword"; };
+#        SSID = { psk = "password"; };
+      };
+    };
+  };
+  sdImage = {
+    imageBaseName  = "aira-sd-image-rpi4";
+    firmwareSize = 128;
+    # This is a hack to avoid replicating config.txt from boot.loader.raspberryPi
+    populateFirmwareCommands = ''
+      ${config.system.build.installBootLoader} ${config.system.build.toplevel} -d ./firmware
+      cp ${pkgs.ubootRaspberryPi4_64bit}/u-boot.bin firmware/u-boot.bin
+    '';
+    populateRootCommands = "";
+  };
+  # the installation media is also the installation target,
+  # so we don't want to provide the installation configuration.nix.
+  installer = {
+    cloneConfigExtra = ''
+  boot = {
+    loader = {
+      grub.enable = false;
+      generic-extlinux-compatible.enable = true;
+      raspberryPi = {
+        enable = true;
+        version = 4;
+        uboot.enable = true;
+      };
+    };
+    kernelPackages = pkgs.linuxPackages_rpi4;
+    kernelParams = [ "cma=256M" "console=ttyS0,115200n8" "console=ttyAMA0,115200n8" "console=tty0" ];
+    initrd.kernelModules =  [ "w1-gpio" "w1-therm" ];
+  };
+
+  networking = {
+    hostName = "aira-rpi4";
+    wireless = {
+      enable = true;  # Enables wireless support via wpa_supplicant.
+      networks = {
+#Def#   Aira = { psk = "airapassword"; };
+#        SSID = { psk = "password"; };
+      };
+    };
+  };
+  environment.systemPackages = with pkgs; [ nano wget ];
+    '';
+  };
+}
+

--- a/nixos/modules/installer/cd-dvd/aira-sd-image-rpi4.nix
+++ b/nixos/modules/installer/cd-dvd/aira-sd-image-rpi4.nix
@@ -30,6 +30,7 @@
     initrd.kernelModules =  [ "w1-gpio" "w1-therm" ];
     consoleLogLevel = lib.mkDefault 7;
   };
+  services.nixosManual.enable = false;
   networking = {
     hostName = "aira-rpi4";
     wireless = {

--- a/nixos/release-aira.nix
+++ b/nixos/release-aira.nix
@@ -62,6 +62,17 @@ in rec {
         ];
     }).config.system.build.sdImage);
 
+  # A bootable SD card image for Raspberry pi 4.
+  aira_image_rpi4 = with import nixpkgsSrc { system = "aarch64-linux"; };
+    lib.hydraJob ((import lib/eval-config.nix {
+      inherit system;
+      modules =
+        [ ./modules/installer/cd-dvd/aira-sd-image-rpi4.nix
+          ./modules/installer/aira.nix
+          ./modules/profiles/aira-foundation.nix
+        ];
+    }).config.system.build.sdImage);
+
   nixpkgs = {
     inherit (nixpkgs')
       tarball
@@ -90,12 +101,13 @@ in rec {
     name = "nixos-${nixos.channel.version}";
     meta = {
       description = "Release-critical builds for the AIRA channel";
-      maintainers = with lib.maintainers; [ akru strdn ];
+      maintainers = with lib.maintainers; [ akru strdn spd ];
     };
     constituents =
       [ nixpkgs.tarball
         ova_image
         sd_image
+        aira_image_rpi4
       ]
       ++ lib.collect lib.isDerivation nixos;
   });


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
