### PR TITLE
liability-nightly service: support IPFS bootstrapping

### DIFF
--- a/nixos/modules/services/robonomics/liability-nightly.nix
+++ b/nixos/modules/services/robonomics/liability-nightly.nix
@@ -82,6 +82,13 @@ in {
         description = "list of IPFS public nodes http provider address";
       };
 
+      ipfs_swarm_connect_addresses = mkOption {
+        type = types.str;
+        default = "";
+        example = "/dnsaddr/bootstrap.aira.life, /dns4/1.pubsub.aira.life/tcp/4001/ipfs/QmdfQmbmXt6sqjZyowxPUsmvBsgSGQjm4VXrV7WGy62dv8";
+        description = "list of IPFS bootstrapping nodes";
+      };
+
       web3_http_provider = mkOption {
         type = types.str;
         default = "http://127.0.0.1:8545";
@@ -130,6 +137,7 @@ in {
               keyfile_password_file:="${cfg.keyfile_password_file}" \
               ipfs_http_provider:="${cfg.ipfs_http_provider}" \
               ipfs_public_providers:="${cfg.ipfs_public_providers}" \
+              ipfs_swarm_connect_addresses:="${cfg.ipfs_swarm_connect_addresses}" \
               web3_http_provider:="${cfg.web3_http_provider}" \
               web3_ws_provider:="${cfg.web3_ws_provider}" \
               enable_aira_graph:="${if cfg.graph then "true" else "false"}" \

--- a/pkgs/applications/science/robotics/aira/robonomics_comm/nightly.nix
+++ b/pkgs/applications/science/robotics/aira/robonomics_comm/nightly.nix
@@ -7,8 +7,8 @@
 }:
 
 let
-  rev = "01bb95914c51c1855224011055f869063b5cbc81";
-  sha256 = "0mpx2mhi3cwnqpcwgq737k3vx2hjj3p1h0j49xa577vdkbphwzqw";
+  rev = "74a9d516d5a4fb27b7c4079dd634e594c38a9635";
+  sha256 = "026rhza297i69xm466nzsw0gqsnx8lrr7sy9h5kdw6d8wc24x1fs";
 
 in mkRosPackage rec {
   name = "${pname}-${version}";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
