### PR TITLE
yggdrasil service: delete duplicate bindsTo

### DIFF
--- a/nixos/modules/services/networking/yggdrasil.nix
+++ b/nixos/modules/services/networking/yggdrasil.nix
@@ -127,16 +127,16 @@ in
           '';
         };
 
-        LinkLocalTCPPort = mkOption { 
+        LinkLocalTCPPort = mkOption {
           type = types.int;
           default = 0;
           description = ''
-            The port number to be used for the link-local TCP listeners for the 
+            The port number to be used for the link-local TCP listeners for the
             configured MulticastInterfaces. This option does not affect listeners
             specified in the Listen option. Unless you plan to firewall link-local
             traffic, it is best to leave this as the default value of 0. This
             option cannot currently be changed by reloading config during runtime.
-          ''; 
+          '';
         };
         IfName = mkOption {
           type = types.str;
@@ -166,7 +166,7 @@ in
           '';
         };
 
-      SessionFirewall = { 
+      SessionFirewall = {
         Enable = mkOption {
           type = types.bool;
           default = false;
@@ -222,7 +222,7 @@ in
         };
       };
 
-      TunnelRouting = { 
+      TunnelRouting = {
         Enable = mkOption {
           type = types.bool;
           default = false;
@@ -323,7 +323,6 @@ in
       path = [ cfg.package ] ++ optional (configProvided && configFileProvided) pkgs.jq;
       bindsTo = [ "network-online.target" ];
       after = [ "network-online.target" ];
-      bindsTo = [ "network-online.target" ];
 
       preStart = if cfg.confFile != null then "" else ''#!${pkgs.bash}/bin/bash
         if [ ! -f /etc/yggdrasil.priv -o ! -f /etc/yggdrasil.pub ]; then


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
