### PR TITLE
substrate_sensor_demo: init 0.1.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -751,6 +751,7 @@
   ./services/robonomics/drone_passport.nix
   ./services/robonomics/drone_flight_report.nix
   ./services/robonomics/sen0233.nix
+  ./services/robonomics/substrate_sensor.nix
   ./services/scheduling/atd.nix
   ./services/scheduling/chronos.nix
   ./services/scheduling/cron.nix

--- a/nixos/modules/services/robonomics/substrate_sensor.nix
+++ b/nixos/modules/services/robonomics/substrate_sensor.nix
@@ -1,0 +1,65 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.substrate_sensor;
+
+in {
+
+  options = {
+    services.substrate_sensor = {
+      enable = mkEnableOption "Substrate Sensor service";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.substrate_sensor_demo;
+        defaultText = "pkgs.substrate_sensor_demo";
+        description = '' '';
+      };
+
+      interval = mkOption {
+        type = types.int;
+        default = 30;
+        description = "Interval in seconds";
+      };
+
+      port = mkOption {
+        type = types.str;
+        default = "/dev/ttyS0";
+        description = "The port where the sensor is";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "liability";
+        description = "User account under which substrate node robonomics runs";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "users";
+        description = "Group under which substrate node robonomics user";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    systemd.services.substrate_sensor = {
+      requires = [ "ipfs.service"  "roscore.service" ];
+      after = [ "ipfs.service" "roscore.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Restart = "on-failure";
+        RestartSec = 5;
+        ExecStart = concatStringsSep " " [
+          ''${pkgs.bash}/bin/bash -c "source ${cfg.package}/setup.bash &&''
+          ''roslaunch substrate_sensor_demo agent.launch interval:=${toString cfg.interval} port:='${cfg.port}'" "''
+        ];
+        User = cfg.user;
+        Group = cfg.group;
+      };
+    };
+  };
+}

--- a/pkgs/applications/science/robotics/aira/substrate_sensor_demo/default.nix
+++ b/pkgs/applications/science/robotics/aira/substrate_sensor_demo/default.nix
@@ -1,0 +1,30 @@
+{ pkgs ? import <nixpkgs> { }
+, stdenv
+, fetchFromGitHub
+, mkRosPackage
+, robonomics_comm
+, python3Packages
+}:
+
+mkRosPackage rec {
+  name = "${pname}-${version}";
+  pname = "substrate_sensor_demo";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "airalab";
+    repo = "${pname}";
+    rev = "03f3e472317305aa79e95fa3effaf3a59111810a";
+    sha256 = "sha256:0nl0h0lq058qwnn6m77qpkwrx5sifpjvl1c8ha3jyzd5cpvhmbn8";
+  };
+
+  propagatedBuildInputs = [ robonomics_comm python3Packages.pyserial ];
+
+  meta = with stdenv.lib; {
+    description = "Agent works with SEN0233 sensor and publishes data with specified interval";
+    homepage = http://github.com/airalab/substrate_sensor_demo;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ vourhey ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25779,6 +25779,8 @@ in
 
   sen0233_sensor_agent = callPackage ../applications/science/robotics/aira/sen0233_sensor_agent {  };
 
+  substrate_sensor_demo = callPackage ../applications/science/robotics/aira/substrate_sensor_demo {  };
+
   complier_service = callPackage ../applications/science/robotics/aira/complier_service {  };
 
   de_dev = callPackage ../applications/science/robotics/aira/de_dev { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
