### PR TITLE
pinatapy: init 0.1.1

### DIFF
--- a/pkgs/development/python-modules/pinatapy/default.nix
+++ b/pkgs/development/python-modules/pinatapy/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, python3
+, python3Packages
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "pinatapy";
+  version = "0.1.1";
+
+  propagatedBuildInputs = with python3Packages; [ requests ];
+
+  src = python3Packages.fetchPypi {
+    inherit version;
+    pname  = "pinatapy-vourhey";
+    sha256 = "1jrpclrlq6c7ycmc8203rr2r4a0dmwcx1qn4482ld5iwchwkzpnc";
+  };
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Non-official Pinata.cloud library.";
+    homepage = https://github.com/vourhey/pinatapy;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ vourhey ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4123,6 +4123,8 @@ in {
 
   pint = callPackage ../development/python-modules/pint { };
 
+  pinatapy = callPackage ../development/python-modules/pinatapy {  };
+
   pygal = callPackage ../development/python-modules/pygal { };
 
   pytaglib = callPackage ../development/python-modules/pytaglib { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

pinatapy: init 0.1.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
