### PR TITLE
Add nightly profiles

### DIFF
--- a/nixos/modules/profiles/aira-foundation-nightly.nix
+++ b/nixos/modules/profiles/aira-foundation-nightly.nix
@@ -1,0 +1,31 @@
+{ config, ... }:
+
+let
+  web3_http_provider = "https://mainnet.infura.io/v3/cd7368514cbd4135b06e2c5581a4fff7";
+  web3_ws_provider = "wss://mainnet.infura.io/ws";
+  lighthouse = "airalab.lighthouse.5.robonomics.eth";
+  factory = "factory.5.robonomics.eth";
+  graph_topic = "graph.5.robonomics.eth";
+  token = "xrt.5.robonomics.eth";
+  ipfs_public_providers="https://ipfs.infura.io:5001";
+  ipfs_swarm_connect_addresses="/dnsaddr/bootstrap.aira.life";
+
+in {
+  # Enable light robot liability service
+  services.liability-nightly = {
+    enable = true;
+    inherit web3_http_provider web3_ws_provider lighthouse factory graph_topic ipfs_public_providers ipfs_swarm_connect_addresses;
+  };
+
+  # Set params for XRT
+  services.erc20 = {
+    enable = true;
+    inherit web3_http_provider web3_ws_provider token factory;
+  };
+
+  # enable separated roscore nodes
+  services.roscore = {
+    enable = true;
+  };
+
+}

--- a/nixos/modules/profiles/aira-sidechain-nightly.nix
+++ b/nixos/modules/profiles/aira-sidechain-nightly.nix
@@ -1,0 +1,32 @@
+{ config, ... }:
+
+let
+  web3_http_provider = "https://sidechain.aira.life/rpc";
+  web3_ws_provider = "wss://sidechain.aira.life/ws";
+  lighthouse = "airalab.lighthouse.5.robonomics.sid";
+  factory = "factory.5.robonomics.sid";
+  graph_topic = "graph.5.robonomics.sid";
+  token = "xrt.5.robonomics.sid";
+  ens = "0xaC4Ac4801b50b74aa3222B5Ba282FF54407B3941";
+  ipfs_public_providers="https://ipfs.infura.io:5001";
+  ipfs_swarm_connect_addresses="/dnsaddr/bootstrap.aira.life";
+
+in {
+  # Enable light robot liability service
+  services.liability-nightly = {
+    enable = true;
+    inherit ens web3_http_provider web3_ws_provider lighthouse factory graph_topic;
+  };
+
+  # Set params for XRT
+  services.erc20 = {
+    enable = true;
+    inherit ens web3_http_provider web3_ws_provider token factory;
+  };
+
+  # enable separated roscore nodes
+  services.roscore = {
+    enable = true;
+  };
+
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Added profiles:
aira-foundation-nightly.nix: liability-nightly service
aira-sidechain-nightly.nix: liability-nightly.service

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
