### PR TITLE
Fix drone_flight_report service

### DIFF
--- a/nixos/modules/services/robonomics/drone_flight_report.nix
+++ b/nixos/modules/services/robonomics/drone_flight_report.nix
@@ -3,7 +3,7 @@
 with lib;
 
 let
-  cfg = config.services.drone_passport;
+  cfg = config.services.drone_flight_report;
 
   operationalToken = "0x7dE91B204C1C737bcEe6F000AAA6569Cf7061cb7";
 

--- a/pkgs/applications/science/robotics/aira/drone_passport_agent/default.nix
+++ b/pkgs/applications/science/robotics/aira/drone_passport_agent/default.nix
@@ -8,13 +8,13 @@
 mkRosPackage rec {
   name = "${pname}-${version}";
   pname = "drone_passport_agent";
-  version = "0.2.1";
+  version = "0.2.2";
 
   src = fetchFromGitHub {
     owner = "DistributedSky";
     repo = "${pname}";
-    rev = "e5f221a03f63ffeeac2f819b6ad23b7216fc6bcc";
-    sha256 = "sha256:0xichhkiw1b4sr3z4arsgpww7r2gwvjl9bv528hsbwpzlxxv1afw";
+    rev = "628c021240410d02737ed7339137b9a77a0c042d";
+    sha256 = "sha256:18l6rgv6gprxqvwic1cwi39a9x9fi7slghk1i1h8h9sgq4036qqn";
   };
   propagatedBuildInputs = [ robonomics_comm pkgs.python37Packages.flask-restful ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

drone_passport_agent: 0.2.1 -> 0.2.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
