### PR TITLE
drone_passport_agent: 0.2.1 -> 0.2.4

### DIFF
--- a/nixos/modules/services/robonomics/drone_passport.nix
+++ b/nixos/modules/services/robonomics/drone_passport.nix
@@ -36,6 +36,18 @@ in {
         description = "Operational token";
       };
 
+      pinata_api_key = mkOption {
+        type = types.str;
+        default = "";
+        description = "Pinata.cloud API key";
+      };
+
+      pinata_secret_api_key = mkOption {
+        type = types.str;
+        default = "";
+        description = "Pinata.cloud secret API key";
+      };
+
       user = mkOption {
         type = types.str;
         default = "liability";
@@ -58,7 +70,9 @@ in {
               login:="${cfg.login}" \
               email_from:="${cfg.email_from}" \
               email_password:="${cfg.email_password}" \
-              token:="${cfg.token}"
+              token:="${cfg.token}" \
+              pinata_api_key:="${cfg.pinata_api_key}" \
+              pinata_secret_api_key:="${cfg.pinata_secret_api_key}"
       '';
 
       serviceConfig = {

--- a/pkgs/applications/science/robotics/aira/drone_passport_agent/default.nix
+++ b/pkgs/applications/science/robotics/aira/drone_passport_agent/default.nix
@@ -8,15 +8,19 @@
 mkRosPackage rec {
   name = "${pname}-${version}";
   pname = "drone_passport_agent";
-  version = "0.2.2";
+  version = "0.2.4";
 
   src = fetchFromGitHub {
     owner = "DistributedSky";
     repo = "${pname}";
-    rev = "628c021240410d02737ed7339137b9a77a0c042d";
-    sha256 = "sha256:18l6rgv6gprxqvwic1cwi39a9x9fi7slghk1i1h8h9sgq4036qqn";
+    rev = "c580c3944b6a589c0ef4474d180a9f7a786cbb58";
+    sha256 = "sha256:0mbar0p9kgxqrvyx4apbx8l8vilbcz3l3cb31x1cgrbjlmk0sh9n";
   };
-  propagatedBuildInputs = [ robonomics_comm pkgs.python37Packages.flask-restful ];
+  propagatedBuildInputs = [
+    robonomics_comm
+    pkgs.python37Packages.flask-restful
+    pkgs.python3Packages.pinatapy
+  ];
 
   meta = with stdenv.lib; {
     description = "ROS-enabled drone passport agent";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

drone_passport_agent: 0.2.1 -> 0.2.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
