### PR TITLE
graphene-sqlalchemy-filter: init 1.10.2

### DIFF
--- a/pkgs/development/python-modules/graphene-sqlalchemy-filter/default.nix
+++ b/pkgs/development/python-modules/graphene-sqlalchemy-filter/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, python3
+, python3Packages
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "graphene-sqlalchemy-filter";
+  version = "1.10.2";
+
+  propagatedBuildInputs = with python3Packages; [ graphene-sqlalchemy ];
+
+  src = python3Packages.fetchPypi {
+    inherit version;
+    pname  = "graphene-sqlalchemy-filter";
+    sha256 = "0gk12r59gibi7pzkf93lh2qfhy76p861s1680xqpf63pr9y8pxyg";
+  };
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Filters for Graphene SQLAlchemy integration";
+    homepage = https://github.com/art1415926535/graphene-sqlalchemy-filter;
+    license = licenses.mit;
+    maintainers = with maintainers; [ vourhey ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3551,6 +3551,8 @@ in {
 
   graphene-sqlalchemy = callPackage ../development/python-modules/graphene-sqlalchemy {  };
 
+  graphene-sqlalchemy-filter = callPackage ../development/python-modules/graphene-sqlalchemy-filter {  };
+
   graphene = callPackage ../development/python-modules/graphene {  };
 
   graphql-relay = callPackage ../development/python-modules/graphql-relay {  };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

graphene-sqlalchemy-filter: init 1.10.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
